### PR TITLE
Mirror updates XML manifests to S3 for the licensing service

### DIFF
--- a/.github/workflows/mirror-to-s3.yml
+++ b/.github/workflows/mirror-to-s3.yml
@@ -1,0 +1,44 @@
+name: Mirror updates manifests to S3
+on:
+  push:
+    branches: [updates.simplerisk.com, updates-test.simplerisk.com]
+
+permissions:
+  id-token: write   # for OIDC
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve channel prefix from branch
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$REF_NAME" = "updates.simplerisk.com" ]; then
+            echo "PREFIX=latest/updates/" >> "$GITHUB_ENV"
+          elif [ "$REF_NAME" = "updates-test.simplerisk.com" ]; then
+            echo "PREFIX=testing/updates/" >> "$GITHUB_ENV"
+          else
+            echo "Unexpected branch: $REF_NAME" >&2
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.UPDATES_PUBLISHER_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upload manifests
+        env:
+          EXTRAS_BUCKET: ${{ vars.EXTRAS_BUCKET }}
+        run: |
+          set -euo pipefail
+          for f in releases.xml Current_Version.xml upgrade_path.xml announcements.xml extra_compatibility.xml; do
+            aws s3 cp "$f" "s3://$EXTRAS_BUCKET/${PREFIX}${f}" \
+              --content-type "text/xml" --no-progress
+          done


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that mirrors this repo's five XML manifests to the shared SimpleRisk extras S3 bucket on every push to a deploy branch, so the `licensing.simplerisk.com` service can serve `updates.simplerisk.com` / `updates-test.simplerisk.com` directly (ahead of a DNS cutover) while keeping `releases.xml` byte-compatible for legacy instances.

## What changed

- New `.github/workflows/mirror-to-s3.yml`. On push:
  - branch `updates.simplerisk.com` → uploads to `s3://<bucket>/latest/updates/`
  - branch `updates-test.simplerisk.com` → uploads to `s3://<bucket>/testing/updates/`
- Uploads exactly: `releases.xml`, `Current_Version.xml`, `upgrade_path.xml`, `announcements.xml`, `extra_compatibility.xml` (Content-Type `text/xml`).
- Auth via GitHub OIDC (`id-token: write`), assuming the `simplerisk-updates-publisher-prod` role created by the licensing CDK stack.
- Branch is matched against a hardcoded allowlist (unknown branch fails closed); `set -euo pipefail` throughout.

## Prerequisites (must be in place before this workflow can run)

1. **CDK deployed** (`licensing.simplerisk.com`) so the `simplerisk-updates-publisher-prod` IAM role exists. Its OIDC trust is scoped to this repo's `updates.simplerisk.com` and `updates-test.simplerisk.com` branches; it has `PutObject` only on `*/updates/*`.
2. **Repo variables** (Settings → Secrets and variables → Actions → Variables):
   - `UPDATES_PUBLISHER_ROLE_ARN` — role ARN from the CDK output
   - `AWS_REGION` — e.g. `us-east-1`
   - `EXTRAS_BUCKET` — `simplerisk-extras-<account>`

## Test plan / verification

- Workflow YAML parses (`yaml.safe_load`).
- Branch→prefix mapping and the bucket/prefix targets match the CDK publisher's OIDC trust + `grant_put` resources exactly (`latest/updates/`, `testing/updates/`).
- After prereqs are met: push to `updates-test.simplerisk.com`, confirm the run uploads all five files, then `aws s3 ls s3://<bucket>/testing/updates/`.

## Merge note

This PR targets **`updates-test.simplerisk.com`** (the test deploy branch). The workflow only runs once it's on a deploy branch and the prerequisites above are satisfied; merging is otherwise a no-op. Propagate to `updates.simplerisk.com` for the prod channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
