### PR TITLE
Promote updates-test → updates.simplerisk.com: mirror manifests on the prod channel

### DIFF
--- a/.github/workflows/mirror-to-s3.yml
+++ b/.github/workflows/mirror-to-s3.yml
@@ -1,0 +1,44 @@
+name: Mirror updates manifests to S3
+on:
+  push:
+    branches: [updates.simplerisk.com, updates-test.simplerisk.com]
+
+permissions:
+  id-token: write   # for OIDC
+  contents: read
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve channel prefix from branch
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ "$REF_NAME" = "updates.simplerisk.com" ]; then
+            echo "PREFIX=latest/updates/" >> "$GITHUB_ENV"
+          elif [ "$REF_NAME" = "updates-test.simplerisk.com" ]; then
+            echo "PREFIX=testing/updates/" >> "$GITHUB_ENV"
+          else
+            echo "Unexpected branch: $REF_NAME" >&2
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.UPDATES_PUBLISHER_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upload manifests
+        env:
+          EXTRAS_BUCKET: ${{ vars.EXTRAS_BUCKET }}
+        run: |
+          set -euo pipefail
+          for f in releases.xml Current_Version.xml upgrade_path.xml announcements.xml extra_compatibility.xml; do
+            aws s3 cp "$f" "s3://$EXTRAS_BUCKET/${PREFIX}${f}" \
+              --content-type "text/xml" --no-progress
+          done


### PR DESCRIPTION
## Summary

Promotes `updates-test.simplerisk.com` → `updates.simplerisk.com` so the S3 mirror workflow runs on the **prod deploy branch**, publishing the five XML manifests to `s3://simplerisk-extras-533140816601/latest/updates/`.

Follow-on to #134 (which enabled this on the test channel — verified: the licensing service serves `releases.xml` from `testing/updates/` via the `updates-test.simplerisk.com` host).

## Commits in this promotion (1)

- `Mirror updates XML manifests to S3 for the licensing service`

## Prerequisites — already satisfied

- CDK deployed (`licensing-prod`): the `simplerisk-updates-publisher-prod` role exists and grants `PutObject` on `latest/updates/*`.
- Repo variables set (`UPDATES_PUBLISHER_ROLE_ARN`, `AWS_REGION`, `EXTRAS_BUCKET`).

## Effect on merge

The mirror workflow runs on the `updates.simplerisk.com` branch → uploads `releases.xml`, `Current_Version.xml`, `upgrade_path.xml`, `announcements.xml`, `extra_compatibility.xml` to `latest/updates/`.

## Verification after merge

- Workflow run is green.
- `curl -H 'Host: updates.simplerisk.com' https://<licensing-prod-alb>/releases.xml` streams the XML (pre-DNS-cutover, via the prod ALB Host rule 427).

## Not included here

**DNS cutover** for `updates.simplerisk.com` / `updates-test.simplerisk.com` → the ALB is a separate, later step. Until then the ALB rules sit idle and only respond to explicit `Host:` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
