### PR TITLE
Restore prod bundle hashes and upgrade path clobbered by the test-branch merge

### DIFF
--- a/extra_compatibility.xml
+++ b/extra_compatibility.xml
@@ -3,12 +3,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -194,12 +188,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -237,12 +225,6 @@
     <assessments>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -452,12 +434,6 @@
     <authentication>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -679,12 +655,6 @@
     <complianceforgescf>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260524-001">
             <appversion>20260519-001</appversion>
@@ -919,12 +889,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -1119,12 +1083,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -1309,12 +1267,6 @@
     <import-export>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -1507,12 +1459,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -1685,12 +1631,6 @@
     <jira>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -1873,12 +1813,6 @@
     <notification>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -2077,12 +2011,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -2249,12 +2177,6 @@
     <advanced_search>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -2437,12 +2359,6 @@
     <separation>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
@@ -2629,12 +2545,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -2810,12 +2720,6 @@
     <upgrade>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260604-001">
             <appversion>20260519-001</appversion>
@@ -3026,12 +2930,6 @@
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
         </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
-        </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>
         </extra>
@@ -3186,12 +3084,6 @@
     <workflows>
         <extra version="20260820-001">
             <appversion>20260820-001</appversion>
-        </extra>
-        <extra version="20260811-001">
-            <appversion>20260811-001</appversion>
-        </extra>
-        <extra version="20260709-001">
-            <appversion>20260709-001</appversion>
         </extra>
         <extra version="20260519-001">
             <appversion>20260519-001</appversion>

--- a/releases.xml
+++ b/releases.xml
@@ -3,8 +3,8 @@
         <release_date>20260820</release_date>
         <release_number>001</release_number>
         <next_release />
-        <bundle_md5>35be3fefdfd7814ce5d17cd17191cdff</bundle_md5>
-        <bundle_sha256>61c78cca0d0a74b891694238d5fda1321afff15bf5da562cea7bc2d3dcc5338d</bundle_sha256>
+        <bundle_md5>9b639134c80d1eee1f8c86355f9c6c68</bundle_md5>
+        <bundle_sha256>3e27941634b3791a17e9f498ea992dc1f2c7aa566e201a8aec6e148120429ecf</bundle_sha256>
         <installer_md5>false</installer_md5>
         <database_schema>
             <en>
@@ -53,120 +53,12 @@
             <workflows version="20260820-001" />
         </extras>
     </release>
-    <release version="20260811-001">
-        <release_date>20260811</release_date>
-        <release_number>001</release_number>
-        <next_release>20260820-001</next_release>
-        <bundle_md5>fb980f836d4ff2a590f25bac4953ef7d</bundle_md5>
-        <bundle_sha256>b403c646250d14dcb609429ec15976748be69d55d8bb485d3a8b5f5f6d5c31a0</bundle_sha256>
-        <installer_md5>false</installer_md5>
-        <database_schema>
-            <en>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-en-20260811-001.sql</url>
-                <sha256>false</sha256>
-            </en>
-            <es>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-es-20260811-001.sql</url>
-                <sha256>false</sha256>
-            </es>
-            <bp>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-bp-20260811-001.sql</url>
-                <sha256>false</sha256>
-            </bp>
-        </database_schema>
-        <release_notes>false</release_notes>
-        <release_update>false</release_update>
-        <virtual_machines>
-            <virtualbox>
-                <virtualbox_md5>false</virtualbox_md5>
-                <virtualbox_sha256>false</virtualbox_sha256>
-            </virtualbox>
-            <vmware>
-                <vmware_md5>false</vmware_md5>
-                <vmware_sha256>false</vmware_sha256>
-            </vmware>
-        </virtual_machines>
-        <extras>
-            <advanced_search version="20260811-001" />
-            <api version="20260811-001" />
-            <artificial_intelligence version="20260811-001" />
-            <assessments version="20260811-001" />
-            <authentication version="20260811-001" />
-            <complianceforgescf version="20260811-001" />
-            <customization version="20260811-001" />
-            <encryption version="20260811-001" />
-            <import-export version="20260811-001" />
-            <incident_management version="20260811-001" />
-            <jira version="20260811-001" />
-            <notification version="20260811-001" />
-            <organizational_hierarchy version="20260811-001" />
-            <separation version="20260811-001" />
-            <ucf version="20260811-001" />
-            <upgrade version="20260811-001" />
-            <vulnmgmt version="20260811-001" />
-            <workflows version="20260811-001" />
-        </extras>
-    </release>
-    <release version="20260709-001">
-        <release_date>20260709</release_date>
-        <release_number>001</release_number>
-        <next_release>20260811-001</next_release>
-        <bundle_md5>6616d359385782e05ba431fb3bd210b6</bundle_md5>
-        <bundle_sha256>a5a3640a5a3a9dacc00ceaaf0fcc050c4a10592b153e5ae2e8faa7ac9cd1c4bb</bundle_sha256>
-        <installer_md5>false</installer_md5>
-        <database_schema>
-            <en>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-en-20260709-001.sql</url>
-                <sha256>false</sha256>
-            </en>
-            <es>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-es-20260709-001.sql</url>
-                <sha256>false</sha256>
-            </es>
-            <bp>
-                <url>https://raw.githubusercontent.com/simplerisk/database/testing/simplerisk-bp-20260709-001.sql</url>
-                <sha256>false</sha256>
-            </bp>
-        </database_schema>
-        <release_notes>false</release_notes>
-        <release_update>false</release_update>
-        <virtual_machines>
-            <virtualbox>
-                <virtualbox_md5>false</virtualbox_md5>
-                <virtualbox_sha256>false</virtualbox_sha256>
-            </virtualbox>
-            <vmware>
-                <vmware_md5>false</vmware_md5>
-                <vmware_sha256>false</vmware_sha256>
-            </vmware>
-        </virtual_machines>
-        <extras>
-            <advanced_search version="20260709-001" />
-            <api version="20260709-001" />
-            <artificial_intelligence version="20260709-001" />
-            <assessments version="20260709-001" />
-            <authentication version="20260709-001" />
-            <complianceforgescf version="20260709-001" />
-            <customization version="20260709-001" />
-            <encryption version="20260709-001" />
-            <import-export version="20260709-001" />
-            <incident_management version="20260709-001" />
-            <jira version="20260709-001" />
-            <notification version="20260709-001" />
-            <organizational_hierarchy version="20260709-001" />
-            <separation version="20260709-001" />
-            <ucf version="20260709-001" />
-            <upgrade version="20260709-001" />
-            <vulnmgmt version="20260709-001" />
-            <workflows version="20260709-001" />
-        </extras>
-    </release>
     <release version="20260519-001">
         <release_date>20260519</release_date>
         <release_number>001</release_number>
-        <next_release>20260709-001</next_release>
-        <bundle_md5>6cce708c9edde0fce04a54934ed1f160</bundle_md5>
-        <bundle_sha256>9741051f053df1c06b19f0e3f7bbc899a6d4f65c0deddc7e45918c76897a506d</bundle_sha256>
+        <next_release>20260820-001</next_release>
+        <bundle_md5>e8c049832041864bfa1f629183b732d2</bundle_md5>
+        <bundle_sha256>7d7fb24214081ef5e51480664d29f084ca6e8e93990fe9da2c957ea1dfff1bb4</bundle_sha256>
         <installer_md5>false</installer_md5>
         <database_schema>false</database_schema>
         <release_notes>false</release_notes>

--- a/upgrade_path.xml
+++ b/upgrade_path.xml
@@ -1,8 +1,6 @@
 <upgrade_path>
     <simplerisk-20260820-001 />
-    <simplerisk-20260811-001>20260820-001</simplerisk-20260811-001>
-    <simplerisk-20260709-001>20260811-001</simplerisk-20260709-001>
-    <simplerisk-20260519-001>20260709-001</simplerisk-20260519-001>
+    <simplerisk-20260519-001>20260820-001</simplerisk-20260519-001>
     <simplerisk-20260422-001>20260519-001</simplerisk-20260422-001>
     <simplerisk-20260302-001>20260422-001</simplerisk-20260302-001>
     <simplerisk-20260224-001>20260302-001</simplerisk-20260224-001>


### PR DESCRIPTION
> [!WARNING]
> **Production feed is currently wrong.** `updates.simplerisk.com` advertises a `bundle_sha256` for the current GA release that matches no published artifact, so bundle-integrity verification fails for 20260820-001. This also blocks every `simplerisk/docker` `master` PR, because the image build verifies against this feed and fails closed.

## Description

#140 merged the `updates-test.simplerisk.com` branch into the prod feed, carrying **testing-channel truth into the production manifests.**

**The VM hashes in that merge are correct and are kept.** This reverts only the parts that describe the prod channel.

### What was wrong, and how each replacement value was confirmed

**1. `20260820-001` bundle hashes** — pointed at the *testing* bundle (`61c78cca…`). The testing bundle for this version was rebuilt at 15:04 today by the `CHERRYPICK-ga-notes-testing` merge, so it is different bytes from the GA bundle promoted at 14:41.

Restored to `3e279416…`, verified by downloading **both** the prod S3 object and the `simplerisk/code` release asset — two independent artifacts that agree with each other and disagree with the feed.

**2. `20260519-001` bundle hashes** — same problem. Restored to `7d7fb242…`, verified against the served prod S3 bundle.

**3. The upgrade chain** routed through releases that never shipped:

```diff
- <simplerisk-20260811-001>20260820-001</simplerisk-20260811-001>
- <simplerisk-20260709-001>20260811-001</simplerisk-20260709-001>
- <simplerisk-20260519-001>20260709-001</simplerisk-20260519-001>
+ <simplerisk-20260519-001>20260820-001</simplerisk-20260519-001>
```

`20260709-001` and `20260811-001` are testing RCs that were **never GA'd** — `simplerisk/code` has no release for either, and `20260820-001` is the combined GA record for all three. Their bundles return **403 on the prod channel**, so a customer on `20260519-001` would have been routed to a bundle that isn't there.

**4.** Their `<release>` and `extra_compatibility` entries are removed for the same reason.

### The resulting diff against the last correct automated state (`0a3cc2d7`) is only:

- the VM hashes (`false` → real) — your VM publish, preserved
- `<extra version="20260519-001">` and `<workflows version="20260519-001" />` — legitimate additions from #140, preserved

Nothing else. That's the check that this reverts the contamination and nothing more.

## Release Notes

_None — internal, but customer-affecting._ Restores correct bundle checksums and upgrade path on the production update feed.

## Manual Validation Steps

1. After merge, confirm the served feed agrees with the served bundle:
   ```bash
   curl -fsSL https://updates.simplerisk.com/releases.xml \
     | sed -n '/<release version="20260820-001">/,/<\/release>/p' | grep bundle_sha256
   curl -fsSL -o /tmp/b.tgz https://simplerisk-downloads.s3.amazonaws.com/public/bundles/simplerisk-20260820-001.tgz
   sha256sum /tmp/b.tgz     # must equal 3e27941634b3791a17e9f498ea992dc1f2c7aa566e201a8aec6e148120429ecf
   ```
2. Re-run checks on a `simplerisk/docker` `master` PR — the image builds should pass again.
3. Confirm the VM hashes survived (they should still be the real values, not `false`).
4. Confirm `upgrade_path.xml` sends `20260519-001` straight to `20260820-001`.

## Type of Change

- [x] Bug fix (production data correction)

## Testing Results

- All three files parse as well-formed XML.
- **9 assertions** run against the corrected files: both bundle hashes match the bytes actually served, VM hashes preserved, testing-only releases absent, upgrade path direct with no phantom hops, `extra_compatibility` cleaned. All pass.
- Both restore values were confirmed by **downloading and hashing the real artifacts**, not by trusting the previous feed contents.
- Diffed against `0a3cc2d7` to prove nothing beyond the contamination was reverted.

## CIA Impact Check

**MAY** negatively impact Confidentiality, Integrity and/or Availability.

### Justification for the change

- The prod feed advertises a checksum matching no published artifact, so any consumer that verifies — the Upgrade Extra's integrity check, installers, the docker image build — fails on the current GA release.
- The upgrade path routes `20260519-001` customers to a bundle that 403s.

### Potential impact on Confidentiality, Integrity and/or Availability

**Integrity (net positive, this is the fix).** Restores agreement between the published checksum and the published bytes. The risk in the change itself is writing a *wrong* value; mitigated by deriving both values from the served artifacts rather than from history, and by confirming 20260820-001's hash independently from two sources.

**Availability (net positive).** Restores one-click upgrade for `20260519-001` customers and unblocks docker CI.

**Confidentiality.** No change.

### Additional Implementation Steps

The feed mirrors to S3 for the licensing service; confirm that mirror picks up the corrected manifests after merge.

**Structural follow-up (not in this PR):** the prod feed has a single writer — `sync_code_repo.yml`'s `update_feeds.sh`, which writes the real GA asset hashes. Merging the testing branch into it bypasses that writer and silently replaces GA truth with RC truth, with no check that would catch it. Worth a branch rule making that merge impossible, plus a decision on pruning abandoned RCs from the test feed.
